### PR TITLE
Update log4j 2.17.0 to 2.17.1

### DIFF
--- a/SpringWorkspace/Proc01/pom.xml
+++ b/SpringWorkspace/Proc01/pom.xml
@@ -86,7 +86,7 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
-			<version>2.17.0</version>
+			<version>2.17.1</version>
 		</dependency>
 
 		<!-- @Inject -->

--- a/SpringWorkspace/Proc01/target/m2e-wtp/web-resources/META-INF/maven/kh.spring/controller/pom.xml
+++ b/SpringWorkspace/Proc01/target/m2e-wtp/web-resources/META-INF/maven/kh.spring/controller/pom.xml
@@ -86,7 +86,7 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
-			<version>2.17.0</version>
+			<version>2.17.1</version>
 		</dependency>
 
 		<!-- @Inject -->

--- a/SpringWorkspace/Spring_04_Board/pom.xml
+++ b/SpringWorkspace/Spring_04_Board/pom.xml
@@ -20,7 +20,7 @@
 			<artifactId>spring-context</artifactId>
 			<version>${org.springframework-version}</version>
 			<exclusions>
-				<!-- Exclude Commons Logging in favor of SLF4j -->
+				<!-- Exclude Commons zging in favor of SLF4j -->
 				<exclusion>
 					<groupId>commons-logging</groupId>
 					<artifactId>commons-logging</artifactId>
@@ -86,7 +86,7 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
-			<version>2.17.0</version>
+			<version>2.17.1</version>
 		</dependency>
 
 		<!-- @Inject -->


### PR DESCRIPTION
Please refer to this article : 

- https://checkmarx.com/blog/cve-2021-44832-apache-log4j-2-17-0-arbitrary-code-execution-via-jdbcappender-datasource-element/
- https://logging.apache.org/log4j/2.x/